### PR TITLE
Add pyyaml deps so pip can build it

### DIFF
--- a/roles/install-deps/tasks/main.yml
+++ b/roles/install-deps/tasks/main.yml
@@ -17,6 +17,8 @@
     - python3-yaml
     - python3-setproctitle
     - python3-zmq
+    - libyaml-dev
+    - libpython2.7-dev
   tags:
     - install
     - deps


### PR DESCRIPTION
The virtualenv needs to install pyyaml, with libyaml support, which requires compiling libyaml so add the libs here.