### PR TITLE
Prefer ansible_distribution over ansible_lsb.id

### DIFF
--- a/roles/configure-nginx/tasks/main.yml
+++ b/roles/configure-nginx/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add nginx stable PPA repository
   apt_repository: repo='ppa:nginx/stable'
-  when: ansible_lsb.id == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags:
     - install
     - deps

--- a/roles/init-conf/tasks/main.yml
+++ b/roles/init-conf/tasks/main.yml
@@ -14,7 +14,7 @@
             mode=0644
             owner=root
             group=root
-  when: ansible_lsb.id == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags:
     - init
     - upstart
@@ -25,7 +25,7 @@
             mode=0644
             owner=root
             group=root
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   notify:
     - reload-systemd
   tags:
@@ -35,7 +35,7 @@
 - name: Enable kernelci systemd service
   command:  /bin/systemctl enable {{ init_service }}.service
             creates=/etc/systemd/system/multi-user.target.wants/{{ init_service }}.service
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   tags:
     - init
     - systemd
@@ -46,7 +46,7 @@
             owner=root
             group=root
             mode=0644
-  when: ansible_lsb.id == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags:
     - init
     - upstart
@@ -57,7 +57,7 @@
             owner=root
             group=root
             mode=0644
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   notify:
     - reload-systemd
   tags:
@@ -70,7 +70,7 @@
             owner=root
             group=root
             mode=0644
-  when: ansible_lsb.id == "Ubuntu"
+  when: ansible_distribution == "Ubuntu"
   tags:
     - init
     - upstart
@@ -81,7 +81,7 @@
             owner=root
             group=root
             mode=0644
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   notify:
     - reload-systemd
   tags:
@@ -91,7 +91,7 @@
 - name: Enable celery systemd service
   command:  /bin/systemctl enable kernelci-celery.service
             creates=/etc/systemd/system/multi-user.target.wants/kernelci-celery.service
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   notify:
     - reload-systemd
   tags:
@@ -101,7 +101,7 @@
 - name: Enable celery beat systemd service
   command:  /bin/systemctl enable kernelci-celery-beat.service
             creates=/etc/systemd/system/multi-user.target.wants/kernelci-celery-beat.service
-  when: ansible_lsb.id == "Debian"
+  when: ansible_distribution == "Debian"
   notify:
     - reload-systemd
   tags:


### PR DESCRIPTION
ansible_lsb.id works only if OS support LSB (and have the correspoding
package).
It does not work on CentOS out of the box and it could be the same on
other OS.
Since ansible_distribution is always availlable, its better to use it.