### PR TITLE
Add kernelci-storage role

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -13,3 +13,4 @@ dbport: 27017
 dbpool: 100
 redis_host: localhost
 redis_port: 6379
+kci_storage_fqdn: storage.kernelci.org

--- a/host_vars/api.kernelci.org
+++ b/host_vars/api.kernelci.org
@@ -1,3 +1,5 @@
 hostname: api.kernelci.org
 role: production
 certname: api.kernelci.org
+storage_certname: storage.kernelci.org
+kci_storage_fqdn: storage.kernelci.org

--- a/host_vars/staging-api.kernelci.org
+++ b/host_vars/staging-api.kernelci.org
@@ -1,3 +1,5 @@
 hostname: staging-api.kernelci.org
 role: production
 certname: staging-api.kernelci.org
+storage_certname: staging-storage.kernelci.org
+kci_storage_fqdn: staging-storage.kernelci.org

--- a/roles/kernelci-storage/meta/main.yml
+++ b/roles/kernelci-storage/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+ - { role: configure-nginx }

--- a/roles/kernelci-storage/tasks/main.yml
+++ b/roles/kernelci-storage/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# app_user need to go throught /var/www
+- name: Fix /var/www/ permissions
+  file: path=/var/www/
+        state=directory
+        mode=0755
+  tags:
+  - kernelci
+  - storage
+
+- name: Create /var/www/images
+  file: path=/var/www/images
+        state=directory
+        owner={{ app_user }}
+        group={{ web_user }}
+        mode=0750
+  tags:
+  - kernelci
+  - storage
+
+- name: configure storage vhost
+  template: src=kci-storage.conf
+        dest=/etc/nginx/sites-available/{{ kci_storage_fqdn }}.conf
+  notify:
+    - reload-nginx
+  tags:
+  - kernelci
+  - storage
+
+- name: Enable storage vhost
+  file:
+    src: /etc/nginx/sites-available/{{ kci_storage_fqdn }}.conf
+    dest: /etc/nginx/sites-enabled/{{ kci_storage_fqdn }}.conf
+    state: link
+  notify:
+    - reload-nginx
+  tags:
+  - kernelci
+  - storage

--- a/roles/kernelci-storage/templates/kci-storage.conf
+++ b/roles/kernelci-storage/templates/kci-storage.conf
@@ -1,0 +1,78 @@
+server {
+    listen *;
+    listen [::];
+
+    server_name {{ kci_storage_fqdn }};
+    root /var/www/images/kernel-ci;
+    charset utf-8;
+
+    access_log /var/log/nginx/{{ kci_storage_fqdn }}-access.log combined buffer=16k;
+    error_log /var/log/nginx/{{ kci_storage_fqdn }}-error.log crit;
+
+    if ($host != "{{ kci_storage_fqdn }}") {
+        return 403;
+    }
+
+    # For letsencrypt auto-renew to work.
+    location /.well-known/ {
+        root /usr/share/nginx/html/{{ kci_storage_fqdn }}/;
+    }
+
+    location / {
+        if (-f $document_root/maintenance.html) {
+            return 503;
+        }
+
+{% if ansible_distribution != "CentOS" %}
+        fancyindex on;
+        fancyindex_exact_size off;
+{% endif %}
+    }
+}
+
+{% if role == "production" %}
+server {
+    listen *:443 http2 ssl;
+    listen [::]:443 http2 ssl;
+
+    ssl_certificate /etc/letsencrypt/live/{{ storage_certname }}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{{ storage_certname }}/privkey.pem;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:HIGH:!ADH:!AECDH:!aNULL:!MD5:!eNULL";
+    ssl_dhparam /etc/ssl/certs/dhparam.pem;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_session_timeout 10m;
+    ssl_session_cache shared:SSL:50m;
+    ssl_stapling on;
+    resolver {{ ssl_stapling_resolver }} ipv6=on;
+    resolver_timeout 3s;
+    add_header Strict-Transport-Security "max-age=31536000; preload";
+
+    server_name {{ kci_storage_fqdn }};
+    root /var/www/images/kernel-ci;
+    charset utf-8;
+
+    access_log /var/log/nginx/{{ kci_storage_fqdn }}-access.log combined buffer=16k;
+    error_log /var/log/nginx/{{ kci_storage_fqdn }}-error.log crit;
+
+    if ($host != "{{ kci_storage_fqdn }}") {
+        return 403;
+    }
+
+    # For letsencrypt auto-renew to work.
+    location /.well-known/ {
+        root /usr/share/nginx/html/{{ kci_storage_fqdn }}/;
+    }
+
+    location / {
+        if (-f $document_root/maintenance.html) {
+            return 503;
+        }
+
+{% if ansible_distribution != "CentOS" %}
+        fancyindex on;
+        fancyindex_exact_size off;
+    }
+{% endif %}
+}
+{% endif %}

--- a/site.yml
+++ b/site.yml
@@ -12,3 +12,4 @@
     - configure-nginx
     - db-backup
     - firewall
+    - kernelci-storage


### PR DESCRIPTION
When callback/boot is used, kernelci-celery try to store boot result in
/var/www/images.

This patch add handling of this directory by ansible.
Since this directory us used also by the "storage" vhost, and that
storage could be seen as a part of backend, it is easier to add a
kernelci-storage role.