### PR TITLE
T7884 kernelci-celery: allow POST requests on /bisect API entry point

### DIFF
--- a/roles/configure-nginx/templates/backend-nginx.conf
+++ b/roles/configure-nginx/templates/backend-nginx.conf
@@ -89,7 +89,7 @@ server {
         include /etc/nginx/custom/backend-proxy.conf;
     }
 
-    location ~ ^/(?=((bisect|count|reports?|statistics|trigger|version)(?!(.*)\.(html?|css|js|png|jpe?g|ico|svg|pdf|php|gif)))) {
+    location ~ ^/(?=((count|reports?|statistics|trigger|version)(?!(.*)\.(html?|css|js|png|jpe?g|ico|svg|pdf|php|gif)))) {
         if ($request_method = 'POST') {
 {% if ansible_distribution != "CentOS" %}
             more_set_headers "Content-Type: application/json; charset=UTF-8";
@@ -102,7 +102,7 @@ server {
         include /etc/nginx/custom/backend-proxy.conf;
     }
 
-    location ~ ^/(?=((batch|boots?|builds?|callback|defconfigs?|jobs?|labs?|send|tests?|tokens?)(?!(.*)\.(html?|css|js|png|jpe?g|ico|svg|pdf|php|gif)))) {
+    location ~ ^/(?=((batch|bisects?|boots?|builds?|callback|defconfigs?|jobs?|labs?|send|tests?|tokens?)(?!(.*)\.(html?|css|js|png|jpe?g|ico|svg|pdf|php|gif)))) {
         client_max_body_size 10m;
         expires 45m;
         include /etc/nginx/custom/backend-maintenance.conf;


### PR DESCRIPTION
Now that we can send bisection results to the backend, we need to
enable POST requests on the /bisect API entry point.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>