### PR TITLE
Allow uploading files up to 1024MB

### DIFF
--- a/roles/configure-nginx/templates/backend-nginx.conf
+++ b/roles/configure-nginx/templates/backend-nginx.conf
@@ -83,7 +83,7 @@ server {
     }
 
     location ~ ^/(?:upload)(.*)$ {
-        client_max_body_size 501m;
+        client_max_body_size 1024m;
 
         include /etc/nginx/custom/backend-maintenance.conf;
         include /etc/nginx/custom/backend-proxy.conf;

--- a/roles/init-conf/templates/kernelci-backend.service
+++ b/roles/init-conf/templates/kernelci-backend.service
@@ -16,7 +16,7 @@ LimitNOFILE=65536
 RestartSec=5
 Restart=always
 WorkingDirectory={{ install_base }}/{{ hostname }}/app
-ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R server.py
+ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R server.py --buffer-size=1073741824
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There were issues with uploading large filesystems to storage.kernelci.org. This change increases the max_buffer_size to 1024MB for /upload location in nginx and for tornado application.