### PR TITLE
update ansible script to works on buster

### DIFF
--- a/roles/configure-nginx/tasks/main.yml
+++ b/roles/configure-nginx/tasks/main.yml
@@ -9,13 +9,14 @@
 
 - name: Install nginx
   when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
-  apt:  pkg={{ item }}
-        state=latest
-        update_cache=yes
-  with_items:
-    - nginx
-    - nginx-extras
-    - libssl-dev
+  apt:  
+    pkg: [
+      'nginx',
+      'nginx-extras',
+      'libssl-dev'
+    ]
+    state: latest
+    update_cache: yes
   tags:
     - web-server
     - deps

--- a/roles/db-backup/tasks/main.yml
+++ b/roles/db-backup/tasks/main.yml
@@ -1,8 +1,21 @@
 ---
+- name: Install OS dependencies - Debian Buster
+  apt:  pkg={{ item }}
+        state=latest
+        update_cache=yes
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"
+  with_items:
+    - s4cmd
+    - xz-utils
+  tags:
+    - backup
+    - deps
+
 - name: Install OS dependencies
   apt:  pkg={{ item }}
         state=latest
         update_cache=yes
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8" or ansible_distribution == "Ubuntu"
   with_items:
     - s3cmd
     - xz-utils
@@ -18,7 +31,7 @@
   tags:
     - backup
 
-- name: Copy s3cmd config file
+- name: Copy s3cmd/s4cmd(for Debian Buster) config file
   template: src=s3cfg
             dest=/home/kernelci/.s3cfg
             owner=kernelci

--- a/roles/db-backup/tasks/main.yml
+++ b/roles/db-backup/tasks/main.yml
@@ -1,24 +1,26 @@
 ---
 - name: Install OS dependencies - Debian Buster
-  apt:  pkg={{ item }}
-        state=latest
-        update_cache=yes
+  apt:  
+    pkg: [
+      's4cmd',
+      'xz-utils'
+    ]
+    state: latest
+    update_cache: yes
   when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"
-  with_items:
-    - s4cmd
-    - xz-utils
   tags:
     - backup
     - deps
 
 - name: Install OS dependencies
-  apt:  pkg={{ item }}
-        state=latest
-        update_cache=yes
+  apt:  
+    pkg: [
+      's3cmd',
+      'xz-utils'
+    ]
+    state: latest
+    update_cache: yes
   when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8" or ansible_distribution == "Ubuntu"
-  with_items:
-    - s3cmd
-    - xz-utils
   tags:
     - backup
     - deps

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
 - name: Install ufw package
-  apt:  pkg=ufw
-        state=latest
-        update_cache=yes
+  apt:  
+    pkg: [
+      'ufw'
+    ]
+    state: latest
+    update_cache: yes
   tags:
     - firewall
     - deps

--- a/roles/install-deps/tasks/install-mongodb.yml
+++ b/roles/install-deps/tasks/install-mongodb.yml
@@ -60,13 +60,14 @@
 
 - name: Install MongoDB on Buster
   when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"
-  apt:  pkg={{ item }}
-        state=latest
-  with_items:
-    - mongodb-org
-    - mongodb-org-shell
-    - mongodb-org-server
-    - mongodb-org-mongos
+  apt:  
+    pkg: [
+      'mongodb-org',
+      'mongodb-org-shell',
+      'mongodb-org-server', 
+      'mongodb-org-mongos'
+    ]
+    state: latest
   tags:
     - install
     - mongodb
@@ -74,11 +75,12 @@
 
 - name: Install MongoDB
   when: ansible_distribution == "Ubuntu" or ( ansible_distribution == "Debian" and ansible_distribution_major_version == "8")
-  apt:  pkg={{ item }}
-        state=latest
-  with_items:
-    - mongodb-org
-    - libsnappy1
+  apt:  
+    pkg: [
+      'mongodb-org',
+      'libsnappy1'
+    ]
+    state: latest
   tags:
     - install
     - mongodb
@@ -86,10 +88,11 @@
 
 - name: Install MongoDB
   when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
-  apt:  pkg={{ item }}
-        state=latest
-  with_items:
-    - mongodb
+  apt:  
+    pkg: [
+      'mongodb',
+    ]
+    state: latest
   tags:
     - install
     - mongodb
@@ -104,10 +107,11 @@
 
 - name: Install MongoDB for CentOS
   when: ansible_distribution == "CentOS"
-  yum:  pkg={{ item }}
-        state=latest
-  with_items:
-    - mongodb-server
+  yum:  
+    pkg: [
+      'mongodb-server'
+    ]
+    state: latest
   tags:
     - install
     - mongodb

--- a/roles/install-deps/tasks/install-mongodb.yml
+++ b/roles/install-deps/tasks/install-mongodb.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Add MongoDB apt key (Ubuntu)
   apt_key:  id=7F0CEB10
             keyserver=hkp://keyserver.ubuntu.com
@@ -18,11 +17,11 @@
     - mongodb
     - deps
 
-- name: Add MongoDB repository (Ubuntu)
-  apt_repository: repo='deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen'
-                  state=present
-                  update_cache=yes
-  when: ansible_distribution == "Ubuntu"
+- name: Add MongoDB apt key (Debian Buster)
+  apt_key:
+      url: https://www.mongodb.org/static/pgp/server-3.2.asc
+      state: present
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"
   tags:
     - install
     - mongodb
@@ -36,7 +35,15 @@
   tags:
     - install
     - mongodb
-    - deps
+
+- name: Add MongoDB repository (Debian Buster)
+  apt_repository: repo='deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse'
+                  state=present
+                  update_cache=yes
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"
+  tags:
+    - install
+    - mongodb    
 
 - name: Disable kernel transparent huge-page defrag
   when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
@@ -51,8 +58,22 @@
     - mongodb
     - kernel
 
+- name: Install MongoDB on Buster
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"
+  apt:  pkg={{ item }}
+        state=latest
+  with_items:
+    - mongodb-org
+    - mongodb-org-shell
+    - mongodb-org-server
+    - mongodb-org-mongos
+  tags:
+    - install
+    - mongodb
+    - deps  
+
 - name: Install MongoDB
-  when: ansible_distribution == "Ubuntu" or ( ansible_distribution == "Debian" and ansible_distribution_major_version == 8)
+  when: ansible_distribution == "Ubuntu" or ( ansible_distribution == "Debian" and ansible_distribution_major_version == "8")
   apt:  pkg={{ item }}
         state=latest
   with_items:
@@ -64,7 +85,7 @@
     - deps
 
 - name: Install MongoDB
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version > 8
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
   apt:  pkg={{ item }}
         state=latest
   with_items:
@@ -72,7 +93,7 @@
   tags:
     - install
     - mongodb
-    - deps
+    - deps  
 
 - name: Install EPEL7
   yum:
@@ -97,15 +118,15 @@
   set_fact:
     mongodb_service: "mongod"
 
-- name: set mongodb_service fact for Debian
-  when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
+- name: set mongodb_service fact for Ubuntu
+  when: ansible_distribution == "Ubuntu"
   set_fact:
     mongodb_service: "mongodb"
 
 - name: set mongodb_service fact for Debian
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version == 8
+  when: ansible_distribution == "Debian"
   set_fact:
-    mongodb_service: "mongod"
+    mongodb_service: "mongod" 
 
 - name: Make sure MongoDB is running
   service:  name={{ mongodb_service }}
@@ -114,3 +135,4 @@
     - install
     - mongodb
     - deps
+    

--- a/roles/install-deps/tasks/install-redis.yml
+++ b/roles/install-deps/tasks/install-redis.yml
@@ -10,7 +10,10 @@
 
 - name: Install redis server
   when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
-  apt: pkg=redis-server
+  apt: 
+    pkg: [
+      'redis-server'
+    ]
   tags:
     - install
     - redis
@@ -18,7 +21,10 @@
 
 - name: Install redis server
   when: ansible_distribution == "CentOS"
-  yum: pkg=redis
+  yum: 
+    pkg: [ 
+      'redis'
+    ]
   tags:
     - install
     - redis

--- a/roles/install-deps/tasks/main.yml
+++ b/roles/install-deps/tasks/main.yml
@@ -20,6 +20,8 @@
     - python3-zmq
     - libyaml-dev
     - libpython2.7-dev
+    - python-selinux
+    - python-semanage
   tags:
     - install
     - deps

--- a/roles/install-deps/tasks/main.yml
+++ b/roles/install-deps/tasks/main.yml
@@ -1,27 +1,24 @@
 ---
 - name: Install OS dependencies
   when: ansible_distribution == "Ubuntu" or ansible_distribution == "Debian"
-  apt:  pkg={{ item }}
-        state=latest
-        update_cache=yes
-  with_items:
-    - build-essential
-    - git
-    - lsb-release
-    - python-apt
-    - python-pip
-    - python-pycurl
-    - python-virtualenv
-    - python2.7-dev
-    - sysfsutils
-    - python3
-    - python3-yaml
-    - python3-setproctitle
-    - python3-zmq
-    - libyaml-dev
-    - libpython2.7-dev
-    - python-selinux
-    - python-semanage
+  apt:  
+        pkg: [
+          'build-essential', 
+          'git', 'lsb-release', 
+          'python-apt', 'python-pip', 
+          'python-pycurl', 
+          'python-virtualenv', 
+          'python2.7-dev', 'sysfsutils', 
+          'python3', 'python3-yaml', 
+          'python3-setproctitle',
+          'python3-zmq', 
+          'libyaml-dev', 
+          'libpython2.7-dev', 
+          'python-selinux', 
+          'python-semanage'
+        ]
+        state: latest
+        update_cache: yes
   tags:
     - install
     - deps
@@ -29,15 +26,15 @@
 - name: Install OS dependencies
   when: ansible_distribution == "CentOS"
   yum:
-        pkg={{ item }}
-  with_items:
-    - PyYAML
-    - git
-    - libselinux-python
-    - libsemanage-python
-    - python-virtualenv
-    - gcc
-    - libyaml-devel
+        pkg: [
+          'PyYAML', 
+          'git', 
+          'libselinux-python', 
+          'libsemanage-python', 
+          'python-virtualenv', 
+          'gcc', 
+          'libyaml-devel'
+        ]
   tags:
     - install
     - deps


### PR DESCRIPTION
Adjustments to run ansible configuration scripts on
Debian Buster and build kernelci-backend locally or
in the place of your preference.

Signed-off-by: Alex P <alexandra.pereira@collabora.com>