### PR TITLE
init-conf: fix mongod service name for Debian

### DIFF
--- a/roles/init-conf/tasks/main.yml
+++ b/roles/init-conf/tasks/main.yml
@@ -10,7 +10,7 @@
   when: ansible_distribution == "Debian" or ansible_distribution == "Ubuntu"
   set_fact:
    redis_service_name: "redis-server"
-   mongodb_service_name: "mongodb"
+   mongodb_service_name: "mongod"
 
 - name: Make sure celery run directory exists
   file: path=/var/run/celery


### PR DESCRIPTION
The Mongo DB service name is now mongod on Debian, as of mongodb-org
v4.2.2 for Buster.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>