### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ Two machines:
 
 * The target machine where the KernelCI infrastructure (front and back end) will be deployed
 	* Target configuration prerequisites
-		* Supported OS: Debian (Stretch and after), CentOS >= 7
+		* Supported OS: Debian Buster, CentOS >= 7
 		* ssh root access, at least for the host machine from where you'll be running ansible
 		* Python >= 2.7.12
 


### PR DESCRIPTION
Currently for example to install mongodb there is strict check for ansible_distribution_major_version = "10" so basically this setup not supporting something except Debian Buster in a fact