### PR TITLE
Rename staging-api. to api.staging.kernelci.org

### DIFF
--- a/host_vars/api.staging.kernelci.org
+++ b/host_vars/api.staging.kernelci.org
@@ -1,0 +1,5 @@
+hostname: api.staging.kernelci.org
+role: production
+certname: api.staging.kernelci.org
+storage_certname: storage.staging.kernelci.org
+kci_storage_fqdn: storage.staging.kernelci.org

--- a/host_vars/staging-api.kernelci.org
+++ b/host_vars/staging-api.kernelci.org
@@ -1,5 +1,0 @@
-hostname: staging-api.kernelci.org
-role: production
-certname: staging-api.kernelci.org
-storage_certname: staging-storage.kernelci.org
-kci_storage_fqdn: staging-storage.kernelci.org

--- a/hosts
+++ b/hosts
@@ -2,7 +2,7 @@
 kernel-ci-backend
 
 [dev]
-staging-api.kernelci.org
+api.staging.kernelci.org
 
 [prod]
 api.kernelci.org


### PR DESCRIPTION
Update the hosts file and host_vars with the new domain names
api.staging.kernelci.org and storage.staging.kernelci.org.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>