### PR TITLE
Update kernelci-backend default branch name

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -5,7 +5,7 @@ hostname: kernelci-backend
 web_user: www-data
 app_user: www-data
 web_root: /usr/share/nginx/html
-git_head: master
+git_head: main
 role: production
 bucket_backup_dir: mongodb
 dbhost: localhost


### PR DESCRIPTION
The default branch name in kernelci-backend repo has been updated to
main on
  https://github.com/kernelci/kernelci-backend/branches

Update the default branch name in ansible playbook to match the changes.

Signed-off-by: Andrew Lee <andrew.lee@collabora.co.uk>