### PR TITLE
host_vars: add missing kci_app_name variable

### DIFF
--- a/host_vars/api.kernelci.org
+++ b/host_vars/api.kernelci.org
@@ -3,3 +3,4 @@ role: production
 certname: api.kernelci.org
 storage_certname: storage.kernelci.org
 kci_storage_fqdn: storage.kernelci.org
+kci_app_name: kernel-ci

--- a/host_vars/api.staging.kernelci.org
+++ b/host_vars/api.staging.kernelci.org
@@ -3,3 +3,4 @@ role: production
 certname: api.staging.kernelci.org
 storage_certname: storage.staging.kernelci.org
 kci_storage_fqdn: storage.staging.kernelci.org
+kci_app_name: kernel-ci


### PR DESCRIPTION
Define the kci_app_name in api.{staging.}kernelci.org host variables.

Fixes: 8afc4ad08f74 ("Add kci_app_name and kci_app_port variables")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>