### PR TITLE
Revert changes for multiple instances of kernelci-backend

### DIFF
--- a/roles/configure-nginx/files/backend-proxy.conf
+++ b/roles/configure-nginx/files/backend-proxy.conf
@@ -12,4 +12,4 @@ proxy_send_timeout 20s;
 proxy_read_timeout 20s;
 proxy_http_version 1.1;
 proxy_set_header Connection "";
-proxy_pass http://backends-{{ kci_app_name }};
+proxy_pass http://backends;

--- a/roles/configure-nginx/tasks/main.yml
+++ b/roles/configure-nginx/tasks/main.yml
@@ -93,7 +93,7 @@
 
 - name: Install nginx upstream definitions
   template: src=backend-upstreams.conf
-            dest=/etc/nginx/conf.d/backend-upstreams-{{ kci_app_name }}.conf
+            dest=/etc/nginx/conf.d/backend-upstreams.conf
             mode=0644
             owner=root
             group=root
@@ -135,8 +135,8 @@
     - web-server
 
 - name: Copy backend proxy configuration
-  template: src=backend-proxy.conf
-        dest=/etc/nginx/custom/backend-proxy-{{ kci_app_name }}.conf
+  copy: src=backend-proxy.conf
+        dest=/etc/nginx/custom/backend-proxy.conf
         owner=root
         group=root
         mode=0644

--- a/roles/configure-nginx/templates/backend-nginx.conf
+++ b/roles/configure-nginx/templates/backend-nginx.conf
@@ -86,7 +86,7 @@ server {
         client_max_body_size 1024m;
 
         include /etc/nginx/custom/backend-maintenance.conf;
-        include /etc/nginx/custom/backend-proxy-{{ kci_app_name }}.conf;
+        include /etc/nginx/custom/backend-proxy.conf;
     }
 
     location ~ ^/(?=((count|reports?|statistics|trigger|version)(?!(.*)\.(html?|css|js|png|jpe?g|ico|svg|pdf|php|gif)))) {
@@ -99,7 +99,7 @@ server {
         expires 45m;
         include /etc/nginx/custom/backend-maintenance.conf;
         include /etc/nginx/custom/backend-proxy-cache.conf;
-        include /etc/nginx/custom/backend-proxy-{{ kci_app_name }}.conf;
+        include /etc/nginx/custom/backend-proxy.conf;
     }
 
     location ~ ^/(?=((batch|bisects?|boots?|builds?|callback|defconfigs?|jobs?|labs?|send|tests?|tokens?)(?!(.*)\.(html?|css|js|png|jpe?g|ico|svg|pdf|php|gif)))) {
@@ -107,6 +107,6 @@ server {
         expires 45m;
         include /etc/nginx/custom/backend-maintenance.conf;
         include /etc/nginx/custom/backend-proxy-cache.conf;
-        include /etc/nginx/custom/backend-proxy-{{ kci_app_name }}.conf;
+        include /etc/nginx/custom/backend-proxy.conf;
     }
 }

--- a/roles/configure-nginx/templates/backend-upstreams.conf
+++ b/roles/configure-nginx/templates/backend-upstreams.conf
@@ -1,4 +1,4 @@
-upstream backends-{{ kci_app_name }} {
-    server 127.0.0.1:{{ kci_app_port }};
+upstream backends {
+    server 127.0.0.1:8888;
     keepalive 20;
 }

--- a/roles/init-conf/tasks/main.yml
+++ b/roles/init-conf/tasks/main.yml
@@ -64,15 +64,15 @@
     - upstart
 
 - name: Install celery systemd services
-  template: src={{ item.template }}.service
-            dest=/etc/systemd/system/{{ item.service_file }}.service
+  template: src={{ item }}.service
+            dest=/etc/systemd/system/{{ item }}.service
             owner=root
             group=root
             mode=0644
   when: ansible_distribution == "Debian" or ansible_distribution == "CentOS"
   with_items:
-    - {template: kernelci-celery, service_file: "kernelci-{{ kci_app_name }}-celery"}
-    - {template: kernelci-celery-beat, service_file: "kernelci-{{ kci_app_name }}-celery-beat"}
+    - kernelci-celery
+    - kernelci-celery-beat
   notify:
     - reload-systemd
   tags:
@@ -95,8 +95,8 @@
             creates=/etc/systemd/system/multi-user.target.wants/{{ item }}.service
   when: ansible_distribution == "Debian" or ansible_distribution == "CentOS"
   with_items:
-    - kernelci-{{ kci_app_name }}-celery
-    - kernelci-{{ kci_app_name }}-celery-beat
+    - kernelci-celery
+    - kernelci-celery-beat
   notify:
     - reload-systemd
   tags:

--- a/roles/init-conf/templates/kernelci-backend.service
+++ b/roles/init-conf/templates/kernelci-backend.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Kernel CI Backend Service for {{ kci_app_name }}
+Description=Kernel CI Backend Service
 Requires={{ mongodb_service_name }}.service
 After={{ mongodb_service_name }}.service
 
@@ -11,12 +11,12 @@ ProtectSystem=full
 ProtectHome=true
 NoNewPrivileges=true
 PrivateTmp=true
-SyslogIdentifier=kernelci-{{ kci_app_name }}-backend
+SyslogIdentifier=kernelci-backend
 LimitNOFILE=65536
 RestartSec=5
 Restart=always
 WorkingDirectory={{ install_base }}/{{ hostname }}/app
-ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R server.py --buffer-size=1073741824 --port={{ kci_app_port }}
+ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R server.py --buffer-size=1073741824
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/init-conf/templates/kernelci-celery-beat.service
+++ b/roles/init-conf/templates/kernelci-celery-beat.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=Kernel CI Backend Celery Beat for {{ kci_app_name }}
-Requires=kernelci-{{ kci_app_name }}-celery.service
-After=kernelci-{{ kci_app_name }}-celery.service
+Description=Kernel CI Backend Celery Beat
+Requires=kernelci-celery.service
+After=kernelci-celery.service
 
 [Service]
 Type=simple
@@ -11,18 +11,18 @@ ProtectSystem=full
 ProtectHome=true
 NoNewPrivileges=true
 PrivateTmp=true
-SyslogIdentifier=kernelci-{{ kci_app_name }}-celery-beat
+SyslogIdentifier=kernelci-celery-beat
 LimitNOFILE=65536
 RestartSec=5
 Restart=always
 RuntimeDirectory=celery
 RuntimeDirectoryMode=755
-PIDFile=/tmp/kernelci-{{ kci_app_name }}-celery-beat.pid
+PIDFile=/tmp/kernelci-celery-beat.pid
 WorkingDirectory={{ install_base }}/{{ hostname }}/app
 ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R \
     {{ install_base }}/.venv/{{ hostname }}/bin/celery beat \
-    --loglevel=INFO --schedule=/var/run/celery/kernelci-{{ kci_app_name }}-beat.db \
-    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery-beat.pid
+    --loglevel=INFO --schedule=/var/run/celery/kernelci-beat.db \
+    --app=taskqueue --pidfile=/tmp/kernelci-celery-beat.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/init-conf/templates/kernelci-celery.service
+++ b/roles/init-conf/templates/kernelci-celery.service
@@ -1,8 +1,8 @@
 [Unit]
-Description=Kernel CI Backend Celery for {{ kci_app_name }}
+Description=Kernel CI Backend Celery
 Requires={{ redis_service_name }}.service
-Wants=kernelci-{{ kci_app_name }}-celery-beat.service
-Before=kernelci-{{ kci_app_name }}-celery-beat.service
+Wants=kernelci-celery-beat.service
+Before=kernelci-celery-beat.service
 
 [Service]
 Type=simple
@@ -24,12 +24,12 @@ WorkingDirectory={{ install_base }}/{{ hostname }}/app
 ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R \
     {{ install_base }}/.venv/{{ hostname }}/bin/celery worker \
     -Ofair --without-gossip --autoscale=24,6 --loglevel=INFO \
-    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery.pid
+    --app=taskqueue --pidfile=/tmp/kernelci-celery.pid
 {% else %}
 ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R \
     {{ install_base }}/.venv/{{ hostname }}/bin/celery worker \
     -Ofair --without-gossip --autoscale=10,2 --loglevel=INFO \
-    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery.pid
+    --app=taskqueue --pidfile=/tmp/kernelci-celery.pid
 {% endif %}
 
 [Install]

--- a/roles/install-app/tasks/main.yml
+++ b/roles/install-app/tasks/main.yml
@@ -52,8 +52,8 @@
     - install
     - app
 
-- name: Does /etc/kernelci/{{ kci_app_name }} exist?
-  file: path=/etc/kernelci/{{ kci_app_name }}
+- name: Does /etc/kernelci exist?
+  file: path=/etc/kernelci
         state=directory
         owner=root
         group=root
@@ -64,7 +64,7 @@
 
 - name: Install configuration file
   template: src=kernelci-backend.cfg
-            dest=/etc/kernelci/{{ kci_app_name }}/kernelci-backend.cfg
+            dest=/etc/kernelci/kernelci-backend.cfg
             owner=root
             group=root
             mode=0644
@@ -75,7 +75,7 @@
 
 - name: Install celery configuration file
   template: src=kernelci-celery.cfg
-            dest=/etc/kernelci/{{ kci_app_name }}/kernelci-celery.cfg
+            dest=/etc/kernelci/kernelci-celery.cfg
             owner=root
             group=root
             mode=0644
@@ -104,4 +104,4 @@
     - docs
 
 - include: selinux.yml
-  when: ansible_selinux is defined and ansible_selinux.status == 'enabled'
+  when: ansible_selinux is defined and ansible_selinux != False


### PR DESCRIPTION
This commit reverts changes that allow running multiple kernelci-backend
instances on a single machine. This is a temporary change until
kernelci-backend main branch follow these changes.
At the moment changes are available on the chromeos.kernelci.org branch.

Signed-off-by: Michal Galka <michal.galka@collabora.com>