### PR TITLE
Add redis_db variable

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -13,6 +13,7 @@ dbport: 27017
 dbpool: 100
 redis_host: localhost
 redis_port: 6379
+redis_db: 0
 kci_storage_fqdn: storage.kernelci.org
 jenkins_url: ""
 jenkins_usr: ""

--- a/roles/install-app/templates/kernelci-celery.cfg
+++ b/roles/install-app/templates/kernelci-celery.cfg
@@ -6,7 +6,8 @@
         "mongodb_user": "",
         "mongodb_password": "",
         "redis_host": "{{ redis_host }}",
-        "redis_port": {{ redis_port }}
+        "redis_port": {{ redis_port }},
+        "redis_db": {{ redis_db }}
     },
     "mail_options": {
         "smtp_port": 465,


### PR DESCRIPTION
It adds possibility to define redis database number which will be used by kernelci-backend celery service. The default value of redis_db is 0 which is default celery configuration for redis broker.