### PR TITLE
T28264 - Add database name and config file path

### DIFF
--- a/roles/init-conf/templates/kernelci-backend.service
+++ b/roles/init-conf/templates/kernelci-backend.service
@@ -16,7 +16,10 @@ LimitNOFILE=65536
 RestartSec=5
 Restart=always
 WorkingDirectory={{ install_base }}/{{ hostname }}/app
-ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R server.py --buffer-size=1073741824 --port={{ kci_app_port }}
+ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R server.py \
+    --buffer-size=1073741824 \
+    --port={{ kci_app_port }} \
+    --config-file=/etc/kernelci/{{ kci_app_name }}/kernelci-backend.cfg
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/init-conf/templates/kernelci-celery-beat.service
+++ b/roles/init-conf/templates/kernelci-celery-beat.service
@@ -22,7 +22,8 @@ WorkingDirectory={{ install_base }}/{{ hostname }}/app
 ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R \
     {{ install_base }}/.venv/{{ hostname }}/bin/celery beat \
     --loglevel=INFO --schedule=/var/run/celery/kernelci-{{ kci_app_name }}-beat.db \
-    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery-beat.pid
+    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery-beat.pid \
+    --user-config=/etc/kernelci/{{ kci_app_name }}/kernelci-celery.cfg
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/init-conf/templates/kernelci-celery.service
+++ b/roles/init-conf/templates/kernelci-celery.service
@@ -24,12 +24,14 @@ WorkingDirectory={{ install_base }}/{{ hostname }}/app
 ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R \
     {{ install_base }}/.venv/{{ hostname }}/bin/celery worker \
     -Ofair --without-gossip --autoscale=24,6 --loglevel=INFO \
-    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery.pid
+    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery.pid \
+    --user-config=/etc/kernelci/{{ kci_app_name }}/kernelci-celery.cfg
 {% else %}
 ExecStart={{ install_base }}/.venv/{{ hostname }}/bin/python -OO -R \
     {{ install_base }}/.venv/{{ hostname }}/bin/celery worker \
     -Ofair --without-gossip --autoscale=10,2 --loglevel=INFO \
-    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery.pid
+    --app=taskqueue --pidfile=/tmp/kernelci-{{ kci_app_name }}-celery.pid \
+    --user-config=/etc/kernelci/{{ kci_app_name }}/kernelci-celery.cfg
 {% endif %}
 
 [Install]

--- a/roles/install-app/templates/kernelci-backend.cfg
+++ b/roles/install-app/templates/kernelci-backend.cfg
@@ -15,4 +15,5 @@ smtp_sender_desc = '{{ smtp_sender_desc }}'
 smtp_password = '{{ smtp_password }}'
 info_email = '{{ info_email }}'
 redis_db = {{ redis_db }}
+mongodb_dbname = '{{ kci_db_name }}'
 {% endif %}

--- a/roles/install-app/templates/kernelci-celery.cfg
+++ b/roles/install-app/templates/kernelci-celery.cfg
@@ -5,6 +5,7 @@
         "mongodb_pool": {{ dbpool }},
         "mongodb_user": "",
         "mongodb_password": "",
+        "mongodb_dbname": "{{ kci_db_name }}",
         "redis_host": "{{ redis_host }}",
         "redis_port": {{ redis_port }},
         "redis_db": {{ redis_db }}


### PR DESCRIPTION
Recent changes in krnelci-backend configuration handling intruduced a
few configure options. This changes introduce proper configuration file
path of the kernelci-backend and celery applications. They also define
mogodb database name as an instance configuration parameter.

NOTE: This PR should be only merged when configuration changes are applied to `kernelci-backend/chromeos.kernelci.org` branch or when `chromeos.kernelci.org` starts using `kernelci-backend/main` branch.